### PR TITLE
add tolerations to each pod

### DIFF
--- a/charts/clearblade-iot-enterprise/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/Chart.yaml
@@ -2,35 +2,35 @@ apiVersion: v2
 name: clearblade-iot-enterprise
 description: ClearBlade IoT Enterprise
 type: application
-version: 3.1.2
+version: 3.1.3
 
 dependencies:
   - name: cb-postgres
-    version: 3.1.2
+    version: 3.1.3
     condition: cb-postgres.enabled
     repository: file://charts/cb-postgres
   - name: cb-haproxy
-    version: 3.1.2
+    version: 3.1.3
     condition: cb-haproxy.enabled
     repository: file://charts/cb-haproxy
   - name: clearblade
-    version: 3.1.2
+    version: 3.1.3
     repository: file://charts/clearblade
   - name: cb-console
-    version: 3.1.2
+    version: 3.1.3
     repository: file://charts/cb-console
   - name: cb-file-hosting
-    version: 3.1.2
+    version: 3.1.3
     repository: file://charts/cb-file-hosting
   - name: cb-redis
-    version: 3.1.2
+    version: 3.1.3
     condition: cb-redis.enabled
     repository: file://charts/cb-redis
   - name: cb-iotcore
-    version: 3.1.2
+    version: 3.1.3
     condition: global.iotCoreEnabled
     repository: file://charts/cb-iotcore
   - name: cb-ia
-    version: 3.1.2
+    version: 3.1.3
     condition: global.iaEnabled
     repository: file://charts/cb-ia

--- a/charts/clearblade-iot-enterprise/charts/cb-console/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-console/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-console
 description: ClearBlade IoT Enterprise - ClearBlade Developer Console
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/cb-console/templates/cb-console-deployment.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-console/templates/cb-console-deployment.yaml
@@ -20,6 +20,15 @@ spec:
       imagePullSecrets:
         - name: gcr-json-key
       {{- end }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       containers:
         - name: cb-console
           image: "gcr.io/api-project-320446546234/cb_console:{{ .Values.global.enterpriseBlueVersion }}"

--- a/charts/clearblade-iot-enterprise/charts/cb-file-hosting/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-file-hosting/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-file-hosting
 description: ClearBlade IoT Enterprise - File Hosting
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/cb-file-hosting/templates/file-hosting-deployment.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-file-hosting/templates/file-hosting-deployment.yaml
@@ -20,6 +20,15 @@ spec:
       imagePullSecrets:
         - name: gcr-json-key
       {{- end }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       containers:
         - name: cb-file-hosting
           image: "gcr.io/api-project-320446546234/file_hosting:{{ .Values.global.enterpriseBlueVersion }}"

--- a/charts/clearblade-iot-enterprise/charts/cb-haproxy/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-haproxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-haproxy
 description: ClearBlade IoT Enterprise - ClearBlade Load Balancer
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/cb-haproxy/templates/haproxy-statefulset.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-haproxy/templates/haproxy-statefulset.yaml
@@ -56,6 +56,15 @@ spec:
       imagePullSecrets:
         - name: gcr-json-key
       {{- end }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       initContainers:
         - name: check-clearblade-readiness
           image: ellerbrock/alpine-bash-curl-ssl

--- a/charts/clearblade-iot-enterprise/charts/cb-ia/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-ia/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-ia
 description: ClearBlade IoT Enterprise - Intelligent Assets sidecar
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/cb-ia/templates/cb-ia-deployment.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-ia/templates/cb-ia-deployment.yaml
@@ -18,6 +18,15 @@ spec:
       imagePullSecrets:
         - name: gcr-json-key
       {{- end }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       {{- if .Values.checkClearbladeReadiness }}
       initContainers:
       - name: check-clearblade-readiness

--- a/charts/clearblade-iot-enterprise/charts/cb-iotcore/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-iotcore/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-iotcore
 description: ClearBlade IoT Enterprise - IoT Core Sidecar
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/cb-iotcore/templates/cb-iotcore-deployment.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-iotcore/templates/cb-iotcore-deployment.yaml
@@ -18,6 +18,15 @@ spec:
       imagePullSecrets:
         - name: gcr-json-key
       {{- end }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       {{- if .Values.checkClearbladeReadiness }}
       initContainers:
       - name: check-clearblade-readiness

--- a/charts/clearblade-iot-enterprise/charts/cb-postgres/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-postgres/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-postgres
 description: ClearBlade IoT Enterprise - Postgres
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/cb-postgres/templates/postgres-statefulset.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-postgres/templates/postgres-statefulset.yaml
@@ -26,6 +26,15 @@ spec:
       {{- end }}
       {{- if eq .Values.global.secretManager "gsm"}}
       serviceAccountName: {{ .Values.global.gcpGSMServiceAccount }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       initContainers:
         - name: init
           image: google/cloud-sdk:slim

--- a/charts/clearblade-iot-enterprise/charts/cb-redis/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-redis/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-redis
 description: ClearBlade IoT Enterprise - Redis
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/cb-redis/templates/redis-deployment.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-redis/templates/redis-deployment.yaml
@@ -21,6 +21,15 @@ spec:
       - name: redis-config
         configMap:
           name: redis-config
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       containers:
       - name: cb-redis
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/clearblade-iot-enterprise/charts/clearblade/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/clearblade/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: clearblade
 description: ClearBlade IoT Enterprise - ClearBlade Node
 type: application
-version: 3.1.2
+version: 3.1.3

--- a/charts/clearblade-iot-enterprise/charts/clearblade/templates/clearblade-statefulset.yaml
+++ b/charts/clearblade-iot-enterprise/charts/clearblade/templates/clearblade-statefulset.yaml
@@ -26,6 +26,15 @@ spec:
       imagePullSecrets:
         - name: gcr-json-key
       {{- end }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       initContainers:
         {{- if not .Values.global.gcpCloudSQLEnabled }}
         - name: check-postgres-readiness
@@ -234,6 +243,15 @@ spec:
       imagePullSecrets:
         - name: gcr-json-key
       {{- end }}
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
+        tolerationSeconds: 0
       initContainers:
         {{- if not .Values.global.gcpCloudSQLEnabled }}
         - name: check-postgres-readiness


### PR DESCRIPTION
Each pod has been assigned 2 toleration's to override the default values (300s). One is for a node in in a 'Not Ready' state, and the other for the 'Unreachable' state. In both cases the pod will now immediately reschedule itself to a healthy node.