### PR TITLE
update haproxy log fmt

### DIFF
--- a/charts/clearblade-iot-enterprise/CHANGELOG.md
+++ b/charts/clearblade-iot-enterprise/CHANGELOG.md
@@ -27,3 +27,7 @@ Requires platform version 2025.2.2
 Ciphers: Haproxy allows the use of weaker ciphers for backwards compatitibility. Disabled by default. New value cb-haproxy.useWeakCiphers
 
 Log Format: ClearBlade now sets the config flag 'log-format' to json. This cannot be overwritten.
+
+## [3.3.4] - 2025-09-10
+
+Haproxy: Updates the log format to add detail for debugging

--- a/charts/clearblade-iot-enterprise/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/Chart.yaml
@@ -2,39 +2,39 @@ apiVersion: v2
 name: clearblade-iot-enterprise
 description: ClearBlade IoT Enterprise
 type: application
-version: 3.3.3
+version: 3.3.4
 
 dependencies:
   - name: cb-postgres
-    version: 3.3.3
+    version: 3.3.4
     condition: cb-postgres.enabled
     repository: file://charts/cb-postgres
   - name: cb-haproxy
-    version: 3.3.3
+    version: 3.3.4
     condition: cb-haproxy.enabled
     repository: file://charts/cb-haproxy
   - name: clearblade
-    version: 3.3.3
+    version: 3.3.4
     repository: file://charts/clearblade
   - name: cb-console
-    version: 3.3.3
+    version: 3.3.4
     repository: file://charts/cb-console
   - name: cb-file-hosting
-    version: 3.3.3
+    version: 3.3.4
     repository: file://charts/cb-file-hosting
   - name: cb-redis
-    version: 3.3.3
+    version: 3.3.4
     condition: cb-redis.enabled
     repository: file://charts/cb-redis
   - name: cb-iotcore
-    version: 3.3.3
+    version: 3.3.4
     condition: global.iotCoreEnabled
     repository: file://charts/cb-iotcore
   - name: cb-ia
-    version: 3.3.3
+    version: 3.3.4
     condition: global.iaEnabled
     repository: file://charts/cb-ia
   - name: cb-ops-console
-    version: 3.3.3
+    version: 3.3.4
     condition: global.opsConsoleEnabled
     repository: file://charts/cb-ops-console

--- a/charts/clearblade-iot-enterprise/charts/cb-console/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-console/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-console
 description: ClearBlade IoT Enterprise - ClearBlade Developer Console
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/cb-file-hosting/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-file-hosting/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-file-hosting
 description: ClearBlade IoT Enterprise - File Hosting
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/cb-haproxy/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-haproxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-haproxy
 description: ClearBlade IoT Enterprise - ClearBlade Load Balancer
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/cb-haproxy/configs/haproxy.cfg
+++ b/charts/clearblade-iot-enterprise/charts/cb-haproxy/configs/haproxy.cfg
@@ -31,7 +31,7 @@ frontend http
   bind *:8080
   bind *:8443 ssl crt /etc/ssl/
   http-request capture req.hdrs len 512
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   
   {{- if .Values.certRenewal }}
   acl acme_req path_beg /.well-known/acme-challenge
@@ -101,7 +101,7 @@ frontend http_mtls
   option http-server-close
   bind *:8444 ssl crt /etc/ssl/ ca-file /etc/mtls/ verify required
   http-request capture req.hdrs len 512
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   redirect scheme https code 301 if !{ ssl_fc }
   default_backend mtls_server
 
@@ -153,7 +153,7 @@ backend ops_console
 backend acme
   mode http
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"tcp","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq","severity":"INFO","remote_addr":"%ci","response_time":%Td,"response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","ssl_error":"%[ssl_fc_err]","ssl_error_str":"%[ssl_fc_err_str]"}'
   server controller cb-haproxy-controller-service.{{ .Values.global.namespace }}.svc.cluster.local:5001 # NO CHECK
 {{- end }}
 
@@ -162,7 +162,7 @@ listen stats
   bind *:9876
   mode http
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   option httplog
   option dontlog-normal
   stats enable
@@ -180,7 +180,7 @@ listen mqtt
   mode tcp
   option tcplog
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"tcp","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq","severity":"INFO","remote_addr":"%ci","response_time":%Td,"response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","ssl_error":"%[ssl_fc_err]","ssl_error_str":"%[ssl_fc_err_str]"}'
   balance leastconn
   server clearblade clearblade-service.{{ default "clearblade" .Values.global.namespace }}.svc.cluster.local:1883 check inter 10000 port 1883
 
@@ -188,7 +188,7 @@ listen mqtt_ws
   mode http
   log global
   option httplog
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   option http-server-close
   option httpclose
   option forwardfor # add X-Forwarded-For header with client IP
@@ -201,7 +201,7 @@ listen mqtt_auth
   mode tcp
   log global
   option tcplog
-  log-format '{"pid":%pid,"haproxy_frontend_type":"tcp","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq","severity":"INFO","remote_addr":"%ci","response_time":%Td,"response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","ssl_error":"%[ssl_fc_err]","ssl_error_str":"%[ssl_fc_err_str]"}'
   bind *:8905
   bind *:8906 ssl crt /etc/ssl/
   balance leastconn
@@ -210,7 +210,7 @@ listen mqtt_auth
 listen mqtt_ws_auth
   mode http
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   option httplog
   option http-server-close
   option httpclose
@@ -224,7 +224,7 @@ listen rpc
   mode tcp
   log global
   option tcplog
-  log-format '{"pid":%pid,"haproxy_frontend_type":"tcp","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq","severity":"INFO","remote_addr":"%ci","response_time":%Td,"response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","ssl_error":"%[ssl_fc_err]","ssl_error_str":"%[ssl_fc_err_str]"}'
   bind *:8950
   bind *:8951 ssl crt /etc/ssl/
   balance leastconn

--- a/charts/clearblade-iot-enterprise/charts/cb-ia/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-ia/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-ia
 description: ClearBlade IoT Enterprise - Intelligent Assets sidecar
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/cb-iotcore/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-iotcore/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-iotcore
 description: ClearBlade IoT Enterprise - IoT Core Sidecar
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/cb-ops-console/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-ops-console/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-ops-console
 description: ClearBlade IoT Enterprise - Ops Console sidecar
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/cb-postgres/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-postgres/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-postgres
 description: ClearBlade IoT Enterprise - Postgres
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/cb-redis/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/cb-redis/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cb-redis
 description: ClearBlade IoT Enterprise - Redis
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-iot-enterprise/charts/clearblade/Chart.yaml
+++ b/charts/clearblade-iot-enterprise/charts/clearblade/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: clearblade
 description: ClearBlade IoT Enterprise - ClearBlade Node
 type: application
-version: 3.3.3
+version: 3.3.4

--- a/charts/clearblade-monitoring/charts/cb-haproxy/configs/haproxy.cfg
+++ b/charts/clearblade-monitoring/charts/cb-haproxy/configs/haproxy.cfg
@@ -32,14 +32,14 @@ frontend http
   option http-server-close # wrong acl was being selected on small percentage of requests. https://stackoverflow.com/questions/12843023/haproxy-sometimes-selects-wrong-acl
   bind *:8080
   http-request capture req.hdrs len 512
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   redirect scheme https code 301 if !{ ssl_fc }
 
 listen stats
   bind *:9876
   mode http
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   option httplog
   option dontlog-normal
   stats enable
@@ -53,7 +53,7 @@ listen prometheus
   bind *:8443 ssl crt /etc/ssl/
   mode http
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   option httplog
   option dontlog-normal
   acl AuthOkay_Prometheus http_auth(prometheus-access-list)
@@ -65,7 +65,7 @@ listen prometheus-managed
   bind *:9000 ssl crt /etc/ssl/
   mode http
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   option httplog
   option dontlog-normal
   acl AuthOkay_Prometheus http_auth(prometheus-access-list)
@@ -81,7 +81,7 @@ listen grafana
   bind *:3000 ssl crt /etc/ssl/
   mode http
   log global
-  log-format '{"pid":%pid,"haproxy_frontend_type":"http","haproxy_process_concurrent_connections":%ac,"haproxy_frontend_concurrent_connections":%fc,"haproxy_backend_concurrent_connections":%bc,"haproxy_server_concurrent_connections":%sc,"haproxy_backend_queue":%bq,"haproxy_server_queue":%sq,"haproxy_client_request_send_time":%Tq,"haproxy_queue_wait_time":%Tw,"haproxy_server_wait_time":%Tc,"haproxy_server_response_send_time":%Tr,"response_time":%Td,"session_duration":%Tt,"request_termination_state":"%tsc","haproxy_server_connection_retries":%rc,"remote_addr":"%ci","remote_port":%cp,"frontend_addr":"%fi","frontend_port":%fp,"frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV", "referer":"%[capture.req.hdr(1),json(utf8s)]","haproxy_frontend_name":"%f","haproxy_backend_name":"%b","haproxy_server_name":"%s","status":%ST,"response_size":%B,"request_size":%U}'
+  log-format '{"message":"%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %r","severity":"INFO","remote_addr":"%ci","status":%ST,"response_time":%Td,"request_method":"%HM","request_uri":"%[capture.req.uri,json(utf8s)]","request_http_version":"%HV","response_size":%B,"request_size":%U,"backend_name":"%b","server_name":"%s","frontend_ssl_version":"%sslv","frontend_ssl_ciphers":"%sslc","referer":"%[capture.req.hdr(1),json(utf8s)]"}'
   option httplog
   option http-server-close
   server grafana-deployment grafana.{{ default "clearblade" .Values.global.namespace }}.svc.cluster.local:3000 check inter 10000 port 3000


### PR DESCRIPTION
- added a "message" field with the default log format string
- removed some of the extra fields that I didn't think were necessary to pull out (queue sizes, etc)
- removed the "haproxy_" prefix from a few fields

The message field will allow the logs to display nicely in the google cloud log explorer. Removing some of the excess fields was done to avoid truncation of the json object, which was causing the json to not be parsed properly. I can update chart versions and add a changelog entry after your other PR is merged in. 