### PR TITLE
Disable connect throttling if haproxyless

### DIFF
--- a/charts/clearblade-iot-enterprise/charts/clearblade/templates/_clearblade_statefulset.tpl
+++ b/charts/clearblade-iot-enterprise/charts/clearblade/templates/_clearblade_statefulset.tpl
@@ -271,6 +271,7 @@ spec:
             {{- end }}
             {{- if .terminate_tls }}
             - "-enable-reverse-proxy=true"
+            - "-max-concurrent-connects-per-node=0"
             - "-use-tls-http=true"
             - "-message-use-tls=true"
             - "-message-auth-use-tls=true"


### PR DESCRIPTION
We should instead be throttling with MaxTlsConnectionsPerNodePerSecond if we're terminating TLS on platform.