### PR TITLE
New alert for shared topic queue messages dropped

### DIFF
--- a/charts/clearblade-monitoring/charts/cb-monitoring/templates/monitoring-config.yaml
+++ b/charts/clearblade-monitoring/charts/cb-monitoring/templates/monitoring-config.yaml
@@ -109,6 +109,15 @@ data:
        annotations:
          summary: "Pod {{ "{{" }} $labels.pod }} is dropping messages"
       {{- end}}
+      {{- if $.Values.alerts.SharedDropsEnabled }}
+     - alert: {{ $.Values.global.customerName }} {{$n.name}} DroppingMessagesInSharedTopicQueue
+       expr: rate(clearblade_mqtt_shared_dropped_messages{service_name!="all_services",namespace="{{ $n.name }}"}[5m]) > {{ $.Values.alerts.SharedDropsThreshold }}
+       labels:
+         priority: {{ $.Values.alerts.SharedDropsPriority }}
+         severity: warning
+       annotations:
+         summary: "Pod {{ "{{" }} $labels.pod }} is dropping messages"
+      {{- end}}
       {{- if $.Values.alerts.adminConnectionsEnabled }}
      - alert: {{ $.Values.global.customerName }} {{$n.name}} HighDatabaseConnections
        expr: pg_stat_database_numbackends{datname="admin",job=~".*{{ $n.name }}"} > {{ $.Values.alerts.adminConnectionsThreshold }}

--- a/charts/clearblade-monitoring/charts/cb-monitoring/values.yaml
+++ b/charts/clearblade-monitoring/charts/cb-monitoring/values.yaml
@@ -47,6 +47,10 @@ alerts:
   LRSDropsEnabled: true
   LRSDropsThreshold: 0
   LRSDropsPriority: low
+  #Shared topic queue dropped messages threshold (5m)
+  SharedDropsEnabled: true
+  SharedDropsThreshold: 0
+  SharedDropsPriority: low
   #Total file descriptors in use threshold
   fileDescriptorsEnabled: true
   fileDescriptorsThreshold: 900000


### PR DESCRIPTION
Ran **/pr main** in Claude. Got this:

 ---                                                                                                                                                                                         
  PR Review: shared-topic-queue-msg-drop-alert → main
                                                                                                                                                                                              
  Overview                                                                                                                                                                                    
                                                                                                                                                                                              
  Adds one new Prometheus alert rule for MQTT shared topic queue dropped messages. Two files changed: monitoring-config.yaml (template) and values.yaml (defaults). Change is small,          
  self-contained, and mirrors existing DroppingMessagesInLRS pattern closely.                                                                                                                 
                                                                                                                                                                                              
  ---             
  Design Assessment
                   
  Approach correct. New alert follows established structure — guarded by {{- if}}, parameterized threshold/priority, consistent metric filter (service_name!="all_services"). No structural
  surprises.                                                                                                                                                                                  
   
  ---                                                                                                                                                                                         
  Findings by Severity
                                                                                                                                                                                              
  MEDIUM — Missing for: duration
                                                                                                                                                                                              
  # LRS alert (existing) — also missing `for:`
  - alert: ... DroppingMessagesInLRS                                                                                                                                                          
    expr: rate(...)
                                                                                                                                                                                              
  # New alert — same omission                                                                                                                                                                 
  - alert: ... DroppingMessagesInSharedTopicQueue
    expr: rate(clearblade_mqtt_shared_dropped_messages{...}[5m]) > {{ $.Values.alerts.SharedDropsThreshold }}                                                                                 
                                                                                                                                                                                              
  No for: means alert fires immediately on first evaluation above threshold. With SharedDropsThreshold: 0, any single dropped message in 5m window triggers. Risk: alert flaps on transient   
  spikes. LRS has same gap — this is consistent but both could benefit from for: 1m or similar.                                                                                               
                                                                                                                                                                                              
  Recommendation: Add for: 1m (or match LRS if LRS gets fixed too).                                                                                                                           
   
  ---                                                                                                                                                                                         
  LOW — Generic summary annotation

  summary: "Pod {{ $labels.pod }} is dropping messages"

  Identical wording to LRS alert. In alertmanager, two firing alerts look the same in the summary field. Operator can't distinguish shared-queue drops from LRS drops at a glance.            
   
  Recommendation: "Pod {{ $labels.pod }} is dropping messages in shared topic queue"                                                                                                          
                  
  ---
  LOW — Default threshold=0 with enabled=true
                                                                                                                                                                                              
  SharedDropsEnabled: true
  SharedDropsThreshold: 0                                                                                                                                                                     
                  
  Matches LRS defaults. Intentional? Threshold=0 means alert on any drop. If this is used in high-throughput environments, expect noisy alerts on rollout. No action needed if this matches   
  operational intent and existing LRS behavior is acceptable.
                                                                                                                                                                                              
  ---             
  Security
          
  No concerns. Read-only monitoring config, no credentials, no exec surfaces.
                                                                                                                                                                                              
  ---
  Performance                                                                                                                                                                                 
                  
  rate(metric[5m]) standard Prometheus query. No cardinality concerns with namespace and service_name filters in place.
                                                                                                                                                                                              
  ---
  Summary                                                                                                                                                                                     
                  
  Clean change, minimal risk. Two issues worth fixing before merge: add for: duration to prevent flapping, and make summary annotation distinct. Both are LOW/MEDIUM and easy one-liners.
                                                                                                                                                                                              
✻ Worked for 56s                
                                                                                                                                                                                              
**AKASH RESPONDED:**
>> I need to match the alert configuration in the existing {{- if $.Values.alerts.LRSDropsEnabled }} block.

**CLAUDE RESPONDED: **                                                                                                
● New block already matches LRS exactly — structure, labels, annotation, no for: clause, all identical. My review findings (missing for:, generic summary) apply equally to LRS, so they're   
  not gaps in this PR. PR is consistent as intended.